### PR TITLE
switch jsdom to jsdom-little to do away with the dependency on contextify

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2,7 +2,7 @@
 // manipulating DOM nodes
 
 // xmldom lets us re-render the DOM from raw HTML
-var jsdom = require('jsdom').jsdom;
+var jsdom = require('jsdom-little').jsdom;
 // xpath lets us use xpath selectors on the rendered DOM
 var xpath = require('xpath');
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "casperjs": "~1.1.0-beta3",
     "shelljs": "~0.3.0",
     "spooky": "~0.2.4",
-    "jsdom": "~0.11.0",
+    "jsdom-little": "0.10.5",
     "download": "~0.1.17",
     "xpath": "0.0.6",
     "winston": "~0.7.3",


### PR DESCRIPTION
Contextify is what is breaking thresher under node-webkit. I tried to produce a nw-gyp build but there were just too many errors and I'd rather not fork dependencies two levels down from thresher to edit their C bindings...

jsdom-little was created for the very purpose of being jsdom without contextify (which creates issues in a number of other contexts too). With just the hotswap the test suite runs without a hitch.
